### PR TITLE
Display values inside of input

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "files": [
     "tags.js",
     "select.js",
+    "values.js",
     "utils.js",
     "select.css",
     "README.md",

--- a/select.css
+++ b/select.css
@@ -9,7 +9,7 @@
 
 .select__dropdown {
 	position: absolute;
-	z-index: 1;
+	z-index: 2;
 	list-style: none;
 	margin: 0;
 	padding: 0;
@@ -64,13 +64,23 @@
 	padding-left: 2em;
 }
 
+.select__input {
+	position: relative;
+}
+.select__input input {
+	position: relative;  /* on top of values */
+}
+
 .select__values {
+	position: absolute;
 	display: inline;
 	padding: 0;
 	margin: 0;
 }
 .select__values li {
 	display: inline-block;
+	position: relative;
+	z-index: 1;  /* on top of input */
 	margin: 0.1em 0.2em;
 	margin-inline-start: 0;
 	cursor: default;
@@ -81,4 +91,11 @@
 	color: inherit;
 	border: 1px solid ThreeDShadow;
 	border-radius: 0.3em;
+}
+
+.select__measure {
+	width: 0;
+	height: 0;
+	overflow: hidden;
+	white-space: pre;
 }

--- a/select.js
+++ b/select.js
@@ -1,4 +1,5 @@
 import { KEYS, randomString, create } from './utils.js';
+import { Values } from './values.js';
 
 export class Select {
 	constructor(id, original) {
@@ -22,9 +23,8 @@ export class Select {
 
 		if (this.original.multiple) {
 			var inputWrapper = create('<div class="select__input">');
-			this.values = create('<ul class="select__values" aria-live="polite">')
-			inputWrapper.append(this.values);
 			inputWrapper.append(this.input);
+			this.values = new Values(this.input, this.original.dataset.selectValueClass);
 			this.wrapper.append(inputWrapper);
 		} else {
 			this.wrapper.append(this.input);
@@ -90,19 +90,9 @@ export class Select {
 			this.input.value = '';
 			this.inputDirty = false;
 			this.updateValidity();
-			this.values.innerHTML = '';
-			Array.from(this.original.options).forEach(op => {
-				if (op.selected && op.label) {
-					var li = document.createElement('li');
-					li.textContent = op.label;
-					li.className = this.original.dataset.selectValueClass || 'select__value';
-					li.onclick = () => {
-						op.selected = false;
-						this.updateValue();
-						this.input.focus();
-					};
-					this.values.append(li);
-				}
+			this.values.update(this.original, () => {
+				this.updateValue();
+				this.input.focus();
 			});
 		} else {
 			if (this.original.selectedOptions.length) {

--- a/select.js
+++ b/select.js
@@ -11,6 +11,8 @@ export class Select {
 		this.createElements();
 		original.hidden = true;
 		original.before(this.wrapper);
+
+		this.updateValue();
 	}
 
 	createElements() {
@@ -58,8 +60,6 @@ export class Select {
 		this.dropdown.onmousedown = event => {
 			event.preventDefault();
 		};
-
-		this.updateValue();
 	}
 
 	isMatch(s) {

--- a/tags.js
+++ b/tags.js
@@ -9,6 +9,8 @@ export class TagInput {
 		this.createElements();
 		original.hidden = true;
 		original.before(this.wrapper);
+
+		this.updateValue();
 	}
 
 	createElements() {
@@ -39,8 +41,6 @@ export class TagInput {
 		this.original.onchange = () => {
 			this.input.setCustomValidity(this.original.validationMessage);
 		};
-
-		this.updateValue();
 	}
 
 	updateValue() {

--- a/tags.js
+++ b/tags.js
@@ -1,4 +1,5 @@
 import { KEYS, randomString, create } from './utils.js';
+import { Values } from './values.js';
 
 export class TagInput {
 	constructor(id, original) {
@@ -14,14 +15,13 @@ export class TagInput {
 	}
 
 	createElements() {
-		this.wrapper = document.createElement('div');
-
-		this.values = create('<ul class="select__values" aria-live="polite">');
-		this.wrapper.append(this.values);
+		this.wrapper = create('<div class="select__input">');
 
 		this.input = document.createElement('input');
 		this.input.className = this.original.dataset.tagsInputClass || '';
 		this.wrapper.append(this.input);
+
+		this.values = new Values(this.input, this.original.dataset.tagsValueClass);
 
 		this.datalist = document.createElement('datalist');
 		this.datalist.innerHTML = this.original.innerHTML;
@@ -45,21 +45,9 @@ export class TagInput {
 
 	updateValue() {
 		this.input.value = '';
-		this.values.innerHTML = '';
-		Array.from(this.original.options).forEach(op => {
-			if (op.selected && op.label) {
-				var li = document.createElement('li');
-				li.textContent = op.label;
-				li.className = this.original.dataset.tagsValueClass || 'select__value';
-				li.onclick = () => {
-					op.selected = false;
-					this.updateValue();
-					this.input.focus();
-				};
-				this.values.append(li);
-			} else if (!op.selected && op.hasAttribute('data-tag-custom')) {
-				op.remove();
-			}
+		this.values.update(this.original, () => {
+			this.updateValue();
+			this.input.focus();
 		});
 	}
 

--- a/values.js
+++ b/values.js
@@ -1,0 +1,29 @@
+import { create } from './utils.js';
+
+export class Values {
+	constructor(input, valueClass) {
+		this.input = input;
+		this.valueClass = valueClass || 'select__value';
+
+		this.el = create('<ul class="select__values" aria-live="polite">');
+		input.before(this.el);
+	}
+
+	update(original, onChange) {
+		this.el.innerHTML = '';
+		Array.from(original.options).forEach(op => {
+			if (op.selected && op.label) {
+				var li = document.createElement('li');
+				li.textContent = op.label;
+				li.className = this.valueClass;
+				li.onclick = () => {
+					op.selected = false;
+					onChange();
+				};
+				this.el.append(li);
+			} else if (!op.selected && op.hasAttribute('data-tag-custom')) {
+				op.remove();
+			}
+		});
+	}
+}

--- a/values.js
+++ b/values.js
@@ -1,12 +1,64 @@
 import { create } from './utils.js';
 
+var createMeasure = function(target) {
+	var wrapper = create('<div class="select__measure" aria-hidden="true">');
+	var span = document.createElement('span');
+	target.after(wrapper);
+	wrapper.append(span);
+
+	return text => {
+		span.textContent = text;
+		var rect = span.getBoundingClientRect();
+		return rect.width;
+	};
+};
+
 export class Values {
 	constructor(input, valueClass) {
+		this.gap = 4;
 		this.input = input;
 		this.valueClass = valueClass || 'select__value';
 
+		this.measure = createMeasure(input);
 		this.el = create('<ul class="select__values" aria-live="polite">');
 		input.before(this.el);
+
+		input.addEventListener('input', this.updateSize.bind(this));
+		window.addEventListener('resize', this.updateSize.bind(this));
+	}
+
+	updateSize() {
+		var style = getComputedStyle(this.input);
+
+		// We may already have changed paddingTop, so we assume that original
+		// paddingTop and paddingBottom are the same
+		var paddingTop = parseInt(style.paddingBottom, 10);
+
+		this.el.style.top = paddingTop + 'px';
+		this.el.style.bottom = style.paddingBottom;
+		this.el.style.left = style.paddingLeft;
+		this.el.style.right = style.paddingRight;
+
+		var n = this.el.children.length;
+		if (n > 0) {
+			var first = this.el.children[0].getBoundingClientRect();
+			var last = this.el.children[n - 1].getBoundingClientRect();
+			var height = last.top - first.top;
+			var width = style.direction === 'ltr'
+				? last.right - first.left
+				: first.right - last.left;
+
+			if (width + this.gap + this.measure(this.input.value) < this.el.clientWidth) {
+				this.input.style.paddingTop = `${paddingTop + height}px`;
+				this.input.style.textIndent = `${width + this.gap}px`;
+			} else {
+				this.input.style.paddingTop = `${paddingTop + height + last.height + this.gap}px`;
+				this.input.style.textIndent = '0';
+			}
+		} else {
+			this.input.style.paddingTop = `${paddingTop}px`;
+			this.input.style.textIndent = '0';
+		}
 	}
 
 	update(original, onChange) {
@@ -25,5 +77,6 @@ export class Values {
 				op.remove();
 			}
 		});
+		this.updateSize();
 	}
 }


### PR DESCRIPTION
So far, selected values have been displayed above the input. This is uncommon. Other libraries (e.g. select2) display the options inside of the input.

The usual way to achieve this is to style a wrapper like an input and hide the actual input inside the wrapper. This requires some hacks, e.g. dynamically resizing the input to its content and forwarding focus. The biggest downside for this particular library is that it uses `<datalist>` which is usually sized in relation to the input, so it looks very awkward.

The approach I ended up with is to keep the input where it is, but add spacing inside of it so the values can be positioned on top.

I did my best in refactoring the code. Still, this adds significant complexity (~14% loc). I am a bit on the fence whether this is worth it or not.

![screenshot](https://github.com/xi/select/assets/202576/7f12a611-d821-4538-9e17-08aec0f567dd)
